### PR TITLE
Fix log4j initialization issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN mvn clean package assembly:single
 FROM eclipse-temurin:11-jre-alpine
 
 COPY --from=builder /home/src/main/resources/logback.xml /home
+COPY --from=builder /home/src/main/resources/log4j.properties /home
 COPY --from=builder /home/target/jpo-aws-depositor-jar-with-dependencies.jar /home
 
 CMD java -Dlogback.configurationFile=/home/logback.xml \

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,10 @@
+# Define the appender for AwsDepositor
+log4j.appender.awsDepositor=org.apache.log4j.ConsoleAppender
+log4j.appender.awsDepositor.layout=org.apache.log4j.PatternLayout
+log4j.appender.awsDepositor.layout.ConversionPattern=%d [%t] %-5p %c{1} - %m%n
+
+# Set the log level for AwsDepositor
+log4j.logger.us.dot.its.jpo.ode.aws.depositor.AwsDepositor=WARN
+log4j.additivity.us.dot.its.jpo.ode.aws.depositor.AwsDepositor=false
+log4j.appender.awsDepositor.threshold=DEBUG
+log4j.appender.awsDepositor.Target=System.out


### PR DESCRIPTION
Adds a log4j.properties file with an appender to fix the WARN messages that were appearing when running the s3-depositor