### PR TITLE
Changed version to 1.4.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-aws-depositor</artifactId>
-  <version>1.1.0</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>JPO AWS Depositor</name>
   <properties>


### PR DESCRIPTION
## Problem
The version in the pom.xml file is outdated.

## Solution
The version has been updated to 1.4.0-SNAPSHOT in the pom.xml.

## Testing
The project compiles successfully using mvn locally.