### PR TITLE
Removed unused variable declaration

### DIFF
--- a/src/main/java/us/dot/its/jpo/ode/aws/depositor/AwsDepositor.java
+++ b/src/main/java/us/dot/its/jpo/ode/aws/depositor/AwsDepositor.java
@@ -405,8 +405,6 @@ public class AwsDepositor {
 	}
 
 	static String getEnvironmentVariable(String variableName, String defaultValue) {
-		// get all environment variables
-		Map<String, String> env = System.getenv();
 		String value = System.getenv(variableName);
 		if (value == null || value.equals("")) {
 		   System.out.println("Something went wrong retrieving the environment variable " + variableName);


### PR DESCRIPTION
## Changes
An unused variable declaration has been removed from the `getEnvironmentVariable()` method in the `AwsDepositor` class.

## Testing
The project has been verified to compile successfully with these changes, and the unit tests passed also.

## USDOT PR
This addresses Dan's comment on the currently open USDOT PR: https://github.com/usdot-jpo-ode/jpo-s3-deposit/pull/64#discussion_r1766939875