### PR TITLE
Set ulimits for Zookeeper in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     image: wurstmeister/zookeeper
     ports:
       - "2181:2181"
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
 
   kafka:
     image: wurstmeister/kafka


### PR DESCRIPTION
## Problem
A "library initialization failed - unable to allocate file descriptor table - out of memory" error is occurring when running the project with docker compose.

## Solution
Resource limits have been added to the zookeeper service.

## Testing
Verified successful Zookeeper startup using docker compose.